### PR TITLE
Add King Harald royal progress tracker to Kommuner Been Map

### DIFF
--- a/KommunerBeenMap/index.html
+++ b/KommunerBeenMap/index.html
@@ -19,8 +19,17 @@
 		</div>
 		<div id="counter">0 av 0 kommuner besøkt</div>
 		<div class="controls">
+			<button id="royal-btn">👑 Se Kongebesøk</button>
 			<button id="share-btn">🔗 Del liste</button>
 			<button id="clear-btn">Fjern alle</button>
+		</div>
+		<div id="royal-info" class="hidden">
+			<p style="font-size: 0.875rem; color: var(--color-text-secondary); margin-bottom: 0.5rem;">
+				Kong Harald og Dronning Sonja har besøkt <strong><span id="royal-count">0</span> av <span id="total-count">0</span></strong> kommuner.
+			</p>
+			<p style="font-size: 0.75rem; color: var(--color-text-light);">
+				Gjenværende 9 kommuner er markert med grått.
+			</p>
 		</div>
 		<div id="list-container">
 			<h3>Besøkte kommuner:</h3>

--- a/KommunerBeenMap/kommuner_been.css
+++ b/KommunerBeenMap/kommuner_been.css
@@ -118,6 +118,45 @@ body {
   gap: 10px;
 }
 
+.hidden {
+  display: none;
+}
+
+#royal-info {
+  background-color: #fef3c7;
+  padding: 12px;
+  border-radius: var(--radius-md);
+  margin: 15px 0;
+  border-left: 4px solid #f59e0b;
+}
+
+#royal-btn {
+  background-color: #f59e0b;
+  color: white;
+  border: none;
+  padding: 10px 20px;
+  font-size: 1em;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-weight: 500;
+  box-shadow: var(--shadow-sm);
+}
+
+#royal-btn:hover {
+  background-color: #d97706;
+  box-shadow: var(--shadow-md);
+  transform: translateY(-1px);
+}
+
+#royal-btn.active {
+  background-color: #059669;
+}
+
+#royal-btn.active:hover {
+  background-color: #047857;
+}
+
 #share-btn {
   background-color: var(--color-primary);
   color: white;


### PR DESCRIPTION
Added fun feature to view King Harald and Queen Sonja's kommune visit progress. They have a goal to visit all Norwegian kommuner and have visited all except 9.

Features:
- Toggle button "👑 Se Kongebesøk" / "👑 Skjul Kongebesøk"
- Shows 356 royal visits in amber/gold color (#f59e0b)
- Shows 9 unvisited kommuner in gray (#9ca3af)
- Info panel displays count: "Kong Harald og Dronning Sonja har besøkt X av Y kommuner"
- User's personal selections (green) remain visible on top of royal view
- Completely non-destructive - doesn't affect user's saved state

Unvisited Kommuner (9 total):
- Beiarn (Nordland)
- Nissedal (Telemark)
- Siljan (Telemark)
- Etne (Vestland)
- Samnanger (Vestland)
- Vaksdal (Vestland)
- Askvoll (Vestland)
- Rindal (Trøndelag)
- Høylandet (Trøndelag)

HTML Changes (index.html):
- Added royal progress toggle button with crown emoji
- Added info panel showing royal visit statistics
- Uses hidden class to toggle visibility

CSS Changes (kommuner_been.css):
- Royal button: Amber background (#f59e0b) → green when active
- Info panel: Yellow background with amber left border
- Smooth transitions and hover effects
- Consistent with unified design system

JavaScript Changes (kommuner_been.js):
- royal_color constant for visited kommuner (#f59e0b amber)
- royal_unvisited_color for unvisited (#9ca3af gray)
- Set of 9 unvisited kommune names
- showingRoyalProgress state tracker
- toggleRoyalProgress() function
- showRoyalProgress() - applies royal colors while preserving user selections
- hideRoyalProgress() - restores default colors
- Updated all interaction handlers (click, hover, remove, clear) to work correctly in both modes
- Royal view layers underneath user selections (green stays on top)

User Experience:
✓ Click button to see royal progress overlay
✓ User's own selections stay visible in green
✓ Can still click to add/remove personal selections ✓ Clear button respects current view mode
✓ Hover effects work correctly in both modes
✓ Toggle on/off anytime without losing state

🤖 Generated with [Claude Code](https://claude.com/claude-code)