### PR TITLE
Add NeTEx Map Explorer for visualizing transit data

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,10 @@
 			<span style="font-weight: 600;">Boat Purchase Calculator</span>
 			<div style="font-size: 0.875rem; color: var(--color-text-light); margin-top: 0.25rem;">Financial planning tool</div>
 		</a>
+		<a href="netex_explorer/index.html">
+			<span style="font-weight: 600;">NeTEx Map Explorer</span>
+			<div style="font-size: 0.875rem; color: var(--color-text-light); margin-top: 0.25rem;">Transit data visualization</div>
+		</a>
 	</div>
 	<div id="content">
 		<main>
@@ -132,6 +136,31 @@
 								<span class="tag">jQuery</span>
 								<span class="tag">Tailwind CSS</span>
 								<span class="tag">URL Encoding</span>
+							</div>
+						</div>
+						<div class="project-arrow">
+							<svg width="20" height="20" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+							</svg>
+						</div>
+					</a>
+
+					<!-- NeTEx Explorer Card -->
+					<a href="netex_explorer/index.html" class="project-card">
+						<div class="project-icon">
+							<svg width="48" height="48" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"></path>
+								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"></path>
+							</svg>
+						</div>
+						<div class="project-content">
+							<h3>NeTEx Map Explorer</h3>
+							<p>Interactive map-based explorer for Norwegian public transit data using DuckDB WASM to query NeTEx parquet files directly in the browser. Visualizes stop places, quays, and transit lines with clustering for performance.</p>
+							<div class="project-tags">
+								<span class="tag">DuckDB WASM</span>
+								<span class="tag">Leaflet</span>
+								<span class="tag">Parquet</span>
+								<span class="tag">Transit Data</span>
 							</div>
 						</div>
 						<div class="project-arrow">

--- a/netex_explorer/app.js
+++ b/netex_explorer/app.js
@@ -1,0 +1,676 @@
+/**
+ * NeTEx Map Explorer
+ * A DuckDB WASM-powered explorer for NeTEx parquet data
+ */
+
+// GCS bucket base URL
+const GCS_BASE = 'https://storage.googleapis.com/netex-parquet-dev/aggregated';
+
+// State
+let db = null;
+let conn = null;
+let map = null;
+let stopPlacesLayer = null;
+let quaysLayer = null;
+let linesLayer = null;
+let currentImportTs = null;
+
+// DOM Elements
+const loadingOverlay = document.getElementById('loading-overlay');
+const loadingStatus = document.getElementById('loading-status');
+const progressFill = document.getElementById('progress-fill');
+
+// Update loading progress
+function updateProgress(percent, status) {
+    progressFill.style.width = `${percent}%`;
+    if (status) {
+        loadingStatus.textContent = status;
+    }
+}
+
+// Initialize the application
+async function init() {
+    try {
+        updateProgress(5, 'Loading DuckDB WASM...');
+
+        // Dynamically import DuckDB WASM
+        const duckdb = await import('https://cdn.jsdelivr.net/npm/@duckdb/duckdb-wasm@1.29.0/+esm');
+
+        updateProgress(15, 'Initializing DuckDB...');
+
+        // Select bundle based on browser features
+        const JSDELIVR_BUNDLES = duckdb.getJsDelivrBundles();
+        const bundle = await duckdb.selectBundle(JSDELIVR_BUNDLES);
+
+        const worker_url = URL.createObjectURL(
+            new Blob([`importScripts("${bundle.mainWorker}");`], { type: 'text/javascript' })
+        );
+
+        const worker = new Worker(worker_url);
+        const logger = new duckdb.ConsoleLogger();
+        db = new duckdb.AsyncDuckDB(logger, worker);
+
+        await db.instantiate(bundle.mainModule, bundle.pthreadWorker);
+        URL.revokeObjectURL(worker_url);
+
+        updateProgress(30, 'Connecting to database...');
+        conn = await db.connect();
+
+        // Install and load httpfs for remote parquet files
+        updateProgress(35, 'Setting up HTTP access...');
+        await conn.query(`INSTALL httpfs`);
+        await conn.query(`LOAD httpfs`);
+
+        // Set S3 region for GCS compatibility (GCS uses S3-compatible API)
+        await conn.query(`SET s3_region='auto'`);
+
+        updateProgress(40, 'Discovering available data...');
+
+        // Find the latest import timestamp by listing available files
+        currentImportTs = await discoverLatestImport();
+
+        updateProgress(50, 'Initializing map...');
+        initMap();
+
+        updateProgress(60, 'Loading entity types...');
+        await loadEntityTypes();
+
+        updateProgress(70, 'Loading stop places...');
+        await loadStopPlaces();
+
+        updateProgress(90, 'Setting up UI...');
+        setupUI();
+
+        updateProgress(100, 'Ready!');
+
+        // Hide loading overlay
+        setTimeout(() => {
+            loadingOverlay.classList.add('hidden');
+        }, 500);
+
+    } catch (error) {
+        console.error('Initialization error:', error);
+        loadingStatus.textContent = `Error: ${error.message}`;
+        loadingStatus.style.color = '#ef4444';
+    }
+}
+
+// Discover the latest import timestamp
+async function discoverLatestImport() {
+    // Use a known recent timestamp based on the bucket listing
+    // In production, you might want to list the bucket or use a metadata endpoint
+    const knownTimestamps = [
+        '2026-01-27T06%3A51%3A53.234399',
+        '2026-01-27T05%3A00%3A24.456629',
+        '2026-01-26T06%3A44%3A00.925295'
+    ];
+
+    for (const ts of knownTimestamps) {
+        try {
+            // Test if this timestamp has data
+            const testUrl = `${GCS_BASE}/import_ts=${ts}/entity_types.parquet`;
+            const response = await fetch(testUrl, { method: 'HEAD' });
+            if (response.ok) {
+                document.getElementById('import-date').textContent = decodeURIComponent(ts).replace('T', ' ').slice(0, 19);
+                return ts;
+            }
+        } catch (e) {
+            continue;
+        }
+    }
+
+    // Fallback to most recent known
+    const fallback = knownTimestamps[0];
+    document.getElementById('import-date').textContent = decodeURIComponent(fallback).replace('T', ' ').slice(0, 19);
+    return fallback;
+}
+
+// Get parquet URL for a table
+function getParquetUrl(tableName) {
+    return `${GCS_BASE}/import_ts=${currentImportTs}/${tableName}.parquet`;
+}
+
+// Initialize Leaflet map
+function initMap() {
+    // Center on Norway
+    map = L.map('map', {
+        center: [64.5, 11.0],
+        zoom: 5,
+        zoomControl: true
+    });
+
+    // Add OpenStreetMap tiles
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+        maxZoom: 19
+    }).addTo(map);
+
+    // Initialize cluster layers
+    stopPlacesLayer = L.markerClusterGroup({
+        chunkedLoading: true,
+        spiderfyOnMaxZoom: true,
+        showCoverageOnHover: false,
+        maxClusterRadius: 50,
+        iconCreateFunction: function(cluster) {
+            const count = cluster.getChildCount();
+            let size = 'small';
+            if (count > 100) size = 'large';
+            else if (count > 10) size = 'medium';
+
+            return L.divIcon({
+                html: `<div>${count}</div>`,
+                className: `marker-cluster marker-cluster-${size}`,
+                iconSize: L.point(40, 40)
+            });
+        }
+    });
+
+    quaysLayer = L.markerClusterGroup({
+        chunkedLoading: true,
+        maxClusterRadius: 30,
+        disableClusteringAtZoom: 15
+    });
+
+    linesLayer = L.layerGroup();
+
+    // Add stop places layer by default
+    map.addLayer(stopPlacesLayer);
+
+    // Zoom to Norway button
+    document.getElementById('zoom-to-norway').addEventListener('click', () => {
+        map.setView([64.5, 11.0], 5);
+    });
+}
+
+// Load entity types
+async function loadEntityTypes() {
+    try {
+        const result = await conn.query(`
+            SELECT entity_type, COUNT(*) as count
+            FROM read_parquet('${getParquetUrl('entities')}')
+            GROUP BY entity_type
+            ORDER BY count DESC
+            LIMIT 30
+        `);
+
+        const rows = result.toArray();
+        const container = document.getElementById('entity-types');
+        container.innerHTML = '';
+
+        let totalCount = 0;
+        rows.forEach(row => {
+            const type = row.entity_type;
+            const count = Number(row.count);
+            totalCount += count;
+
+            const tag = document.createElement('span');
+            tag.className = 'entity-type-tag';
+            tag.textContent = `${type} (${count.toLocaleString()})`;
+            tag.dataset.type = type;
+            tag.addEventListener('click', () => {
+                tag.classList.toggle('active');
+                filterByEntityType(type, tag.classList.contains('active'));
+            });
+            container.appendChild(tag);
+        });
+
+        document.getElementById('entity-count').textContent = totalCount.toLocaleString();
+
+    } catch (error) {
+        console.error('Error loading entity types:', error);
+        document.getElementById('entity-types').innerHTML =
+            `<p class="error-message">Error loading types: ${error.message}</p>`;
+    }
+}
+
+// Load stop places with coordinates
+async function loadStopPlaces() {
+    try {
+        updateProgress(72, 'Querying stop places...');
+
+        // Query to get stop places with their coordinates
+        // NeTEx stores coordinates in entity_values or as attributes
+        const result = await conn.query(`
+            WITH stop_entities AS (
+                SELECT
+                    e.entity_id,
+                    e.entity_type,
+                    e.codespace_id
+                FROM read_parquet('${getParquetUrl('entities')}') e
+                WHERE e.entity_type IN ('StopPlace', 'Quay')
+                LIMIT 50000
+            ),
+            entity_names AS (
+                SELECT
+                    ev.entity_id,
+                    ev.value as name
+                FROM read_parquet('${getParquetUrl('entity_values')}') ev
+                WHERE ev.attribute = 'Name'
+            ),
+            entity_lats AS (
+                SELECT
+                    ev.entity_id,
+                    TRY_CAST(ev.value AS DOUBLE) as latitude
+                FROM read_parquet('${getParquetUrl('entity_values')}') ev
+                WHERE ev.attribute = 'Latitude'
+                  AND TRY_CAST(ev.value AS DOUBLE) IS NOT NULL
+            ),
+            entity_lons AS (
+                SELECT
+                    ev.entity_id,
+                    TRY_CAST(ev.value AS DOUBLE) as longitude
+                FROM read_parquet('${getParquetUrl('entity_values')}') ev
+                WHERE ev.attribute = 'Longitude'
+                  AND TRY_CAST(ev.value AS DOUBLE) IS NOT NULL
+            )
+            SELECT
+                se.entity_id,
+                se.entity_type,
+                se.codespace_id,
+                en.name,
+                el.latitude,
+                elo.longitude
+            FROM stop_entities se
+            LEFT JOIN entity_names en ON se.entity_id = en.entity_id
+            LEFT JOIN entity_lats el ON se.entity_id = el.entity_id
+            LEFT JOIN entity_lons elo ON se.entity_id = elo.entity_id
+            WHERE el.latitude IS NOT NULL
+              AND elo.longitude IS NOT NULL
+              AND el.latitude BETWEEN 57 AND 72
+              AND elo.longitude BETWEEN 4 AND 32
+        `);
+
+        const rows = result.toArray();
+
+        updateProgress(80, `Processing ${rows.length} locations...`);
+
+        let stopCount = 0;
+        let quayCount = 0;
+        const markers = [];
+        const quayMarkers = [];
+
+        rows.forEach(row => {
+            const lat = row.latitude;
+            const lon = row.longitude;
+            const name = row.name || row.entity_id;
+            const type = row.entity_type;
+            const entityId = row.entity_id;
+
+            if (lat && lon && !isNaN(lat) && !isNaN(lon)) {
+                const marker = L.circleMarker([lat, lon], {
+                    radius: type === 'StopPlace' ? 6 : 4,
+                    fillColor: type === 'StopPlace' ? '#2563eb' : '#10b981',
+                    color: '#ffffff',
+                    weight: 2,
+                    opacity: 1,
+                    fillOpacity: 0.8
+                });
+
+                marker.bindPopup(`
+                    <h4>${name}</h4>
+                    <p><strong>Type:</strong> ${type}</p>
+                    <p><strong>ID:</strong> ${entityId}</p>
+                    <p><strong>Coordinates:</strong> ${lat.toFixed(5)}, ${lon.toFixed(5)}</p>
+                `);
+
+                marker.on('click', () => showEntityDetails(entityId, name, type, lat, lon));
+
+                if (type === 'StopPlace') {
+                    markers.push(marker);
+                    stopCount++;
+                } else {
+                    quayMarkers.push(marker);
+                    quayCount++;
+                }
+            }
+        });
+
+        // Add markers to layers
+        stopPlacesLayer.addLayers(markers);
+        quaysLayer.addLayers(quayMarkers);
+
+        // Update counts
+        document.getElementById('stops-count').textContent = stopCount.toLocaleString();
+        document.getElementById('quays-count').textContent = quayCount.toLocaleString();
+
+        console.log(`Loaded ${stopCount} stop places and ${quayCount} quays`);
+
+    } catch (error) {
+        console.error('Error loading stop places:', error);
+        document.getElementById('stops-count').textContent = 'Error';
+    }
+}
+
+// Load lines
+async function loadLines() {
+    try {
+        const result = await conn.query(`
+            SELECT
+                e.entity_id,
+                e.entity_type,
+                e.codespace_id
+            FROM read_parquet('${getParquetUrl('entities')}') e
+            WHERE e.entity_type = 'Line'
+            LIMIT 1000
+        `);
+
+        const rows = result.toArray();
+        document.getElementById('lines-count').textContent = rows.length.toLocaleString();
+
+        // Lines don't have direct geometry - they're defined through ServiceJourneyPatterns
+        // For now, just count them
+
+    } catch (error) {
+        console.error('Error loading lines:', error);
+        document.getElementById('lines-count').textContent = 'Error';
+    }
+}
+
+// Show entity details in sidebar
+async function showEntityDetails(entityId, name, type, lat, lon) {
+    const panel = document.getElementById('details-panel');
+    const details = document.getElementById('entity-details');
+
+    panel.style.display = 'block';
+
+    details.innerHTML = `
+        <h4>${name}</h4>
+        <div class="detail-row">
+            <span class="detail-label">Type</span>
+            <span class="detail-value">${type}</span>
+        </div>
+        <div class="detail-row">
+            <span class="detail-label">Entity ID</span>
+            <span class="detail-value">${entityId}</span>
+        </div>
+        <div class="detail-row">
+            <span class="detail-label">Latitude</span>
+            <span class="detail-value">${lat?.toFixed(6) || 'N/A'}</span>
+        </div>
+        <div class="detail-row">
+            <span class="detail-label">Longitude</span>
+            <span class="detail-value">${lon?.toFixed(6) || 'N/A'}</span>
+        </div>
+        <p class="loading-text" id="loading-more-details">Loading additional details...</p>
+    `;
+
+    // Load additional details
+    try {
+        const valuesResult = await conn.query(`
+            SELECT attribute, value
+            FROM read_parquet('${getParquetUrl('entity_values')}')
+            WHERE entity_id = '${entityId}'
+            LIMIT 20
+        `);
+
+        const values = valuesResult.toArray();
+        const loadingEl = document.getElementById('loading-more-details');
+
+        if (values.length > 0) {
+            let additionalHtml = '';
+            values.forEach(row => {
+                if (row.attribute !== 'Name' && row.attribute !== 'Latitude' && row.attribute !== 'Longitude') {
+                    additionalHtml += `
+                        <div class="detail-row">
+                            <span class="detail-label">${row.attribute}</span>
+                            <span class="detail-value">${row.value || 'N/A'}</span>
+                        </div>
+                    `;
+                }
+            });
+            loadingEl.outerHTML = additionalHtml || '<p class="loading-text">No additional attributes</p>';
+        } else {
+            loadingEl.textContent = 'No additional attributes';
+        }
+    } catch (error) {
+        console.error('Error loading entity details:', error);
+        document.getElementById('loading-more-details').textContent = 'Error loading details';
+    }
+}
+
+// Filter by entity type
+function filterByEntityType(type, active) {
+    console.log(`Filter by ${type}: ${active}`);
+    // For now, just log - full implementation would filter the map
+}
+
+// Search stop places
+async function searchStopPlaces(query) {
+    const resultsContainer = document.getElementById('search-results');
+
+    if (!query || query.length < 2) {
+        resultsContainer.innerHTML = '';
+        return;
+    }
+
+    resultsContainer.innerHTML = '<p class="loading-text">Searching...</p>';
+
+    try {
+        const result = await conn.query(`
+            WITH stop_entities AS (
+                SELECT entity_id, entity_type
+                FROM read_parquet('${getParquetUrl('entities')}')
+                WHERE entity_type IN ('StopPlace', 'Quay')
+            ),
+            entity_names AS (
+                SELECT entity_id, value as name
+                FROM read_parquet('${getParquetUrl('entity_values')}')
+                WHERE attribute = 'Name'
+                  AND LOWER(value) LIKE LOWER('%${query.replace(/'/g, "''")}%')
+            ),
+            entity_lats AS (
+                SELECT entity_id, TRY_CAST(value AS DOUBLE) as latitude
+                FROM read_parquet('${getParquetUrl('entity_values')}')
+                WHERE attribute = 'Latitude'
+            ),
+            entity_lons AS (
+                SELECT entity_id, TRY_CAST(value AS DOUBLE) as longitude
+                FROM read_parquet('${getParquetUrl('entity_values')}')
+                WHERE attribute = 'Longitude'
+            )
+            SELECT
+                se.entity_id,
+                se.entity_type,
+                en.name,
+                el.latitude,
+                elo.longitude
+            FROM stop_entities se
+            INNER JOIN entity_names en ON se.entity_id = en.entity_id
+            LEFT JOIN entity_lats el ON se.entity_id = el.entity_id
+            LEFT JOIN entity_lons elo ON se.entity_id = elo.entity_id
+            WHERE el.latitude IS NOT NULL AND elo.longitude IS NOT NULL
+            LIMIT 20
+        `);
+
+        const rows = result.toArray();
+
+        if (rows.length === 0) {
+            resultsContainer.innerHTML = '<p class="loading-text">No results found</p>';
+            return;
+        }
+
+        resultsContainer.innerHTML = rows.map(row => `
+            <div class="search-result-item"
+                 data-lat="${row.latitude}"
+                 data-lon="${row.longitude}"
+                 data-id="${row.entity_id}"
+                 data-name="${row.name}"
+                 data-type="${row.entity_type}">
+                <div class="search-result-name">${row.name}</div>
+                <div class="search-result-type">${row.entity_type} - ${row.entity_id}</div>
+            </div>
+        `).join('');
+
+        // Add click handlers
+        resultsContainer.querySelectorAll('.search-result-item').forEach(item => {
+            item.addEventListener('click', () => {
+                const lat = parseFloat(item.dataset.lat);
+                const lon = parseFloat(item.dataset.lon);
+                const name = item.dataset.name;
+                const type = item.dataset.type;
+                const id = item.dataset.id;
+
+                map.setView([lat, lon], 15);
+                showEntityDetails(id, name, type, lat, lon);
+
+                // Create temporary marker
+                L.popup()
+                    .setLatLng([lat, lon])
+                    .setContent(`<h4>${name}</h4><p>${type}</p>`)
+                    .openOn(map);
+            });
+        });
+
+    } catch (error) {
+        console.error('Search error:', error);
+        resultsContainer.innerHTML = `<p class="error-message">Search error: ${error.message}</p>`;
+    }
+}
+
+// Run custom SQL query
+async function runQuery(sql) {
+    const resultsContainer = document.getElementById('query-results');
+    resultsContainer.innerHTML = '<p class="loading-text">Running query...</p>';
+
+    try {
+        // Replace table names with parquet URLs
+        let processedSql = sql
+            .replace(/FROM\s+entities/gi, `FROM read_parquet('${getParquetUrl('entities')}')`)
+            .replace(/FROM\s+entity_values/gi, `FROM read_parquet('${getParquetUrl('entity_values')}')`)
+            .replace(/FROM\s+refs/gi, `FROM read_parquet('${getParquetUrl('refs')}')`)
+            .replace(/FROM\s+entity_types/gi, `FROM read_parquet('${getParquetUrl('entity_types')}')`)
+            .replace(/FROM\s+ref_types/gi, `FROM read_parquet('${getParquetUrl('ref_types')}')`)
+            .replace(/FROM\s+codespaces/gi, `FROM read_parquet('${getParquetUrl('codespaces')}')`)
+            .replace(/FROM\s+files/gi, `FROM read_parquet('${getParquetUrl('files')}')`);
+
+        const result = await conn.query(processedSql);
+        const rows = result.toArray();
+
+        if (rows.length === 0) {
+            resultsContainer.innerHTML = '<p class="loading-text">No results</p>';
+            return;
+        }
+
+        // Build table
+        const columns = Object.keys(rows[0]);
+        let tableHtml = '<table><thead><tr>';
+        columns.forEach(col => {
+            tableHtml += `<th>${col}</th>`;
+        });
+        tableHtml += '</tr></thead><tbody>';
+
+        rows.forEach(row => {
+            tableHtml += '<tr>';
+            columns.forEach(col => {
+                const value = row[col];
+                const displayValue = value === null ? 'NULL' :
+                    (typeof value === 'object' ? JSON.stringify(value) : String(value));
+                tableHtml += `<td>${displayValue.substring(0, 100)}</td>`;
+            });
+            tableHtml += '</tr>';
+        });
+
+        tableHtml += '</tbody></table>';
+        resultsContainer.innerHTML = tableHtml;
+
+    } catch (error) {
+        console.error('Query error:', error);
+        resultsContainer.innerHTML = `<p class="error-message">Query error: ${error.message}</p>`;
+    }
+}
+
+// Setup UI event handlers
+function setupUI() {
+    // Mobile menu
+    const sidebar = document.getElementById('sidebar');
+    const mobileMenuBtn = document.getElementById('mobile-menu-btn');
+    const mobileClose = document.getElementById('mobile-close');
+
+    mobileMenuBtn.addEventListener('click', () => {
+        sidebar.classList.add('open');
+    });
+
+    mobileClose.addEventListener('click', () => {
+        sidebar.classList.remove('open');
+    });
+
+    // Layer toggles
+    document.getElementById('layer-stops').addEventListener('change', (e) => {
+        if (e.target.checked) {
+            map.addLayer(stopPlacesLayer);
+        } else {
+            map.removeLayer(stopPlacesLayer);
+        }
+    });
+
+    document.getElementById('layer-quays').addEventListener('change', (e) => {
+        if (e.target.checked) {
+            map.addLayer(quaysLayer);
+        } else {
+            map.removeLayer(quaysLayer);
+        }
+    });
+
+    document.getElementById('layer-lines').addEventListener('change', async (e) => {
+        if (e.target.checked) {
+            await loadLines();
+            map.addLayer(linesLayer);
+        } else {
+            map.removeLayer(linesLayer);
+        }
+    });
+
+    // Search
+    const searchInput = document.getElementById('search-input');
+    const searchBtn = document.getElementById('search-btn');
+
+    let searchTimeout;
+    searchInput.addEventListener('input', () => {
+        clearTimeout(searchTimeout);
+        searchTimeout = setTimeout(() => {
+            searchStopPlaces(searchInput.value);
+        }, 300);
+    });
+
+    searchBtn.addEventListener('click', () => {
+        searchStopPlaces(searchInput.value);
+    });
+
+    searchInput.addEventListener('keypress', (e) => {
+        if (e.key === 'Enter') {
+            searchStopPlaces(searchInput.value);
+        }
+    });
+
+    // Collapsible panels
+    document.querySelectorAll('.panel-header[data-toggle]').forEach(header => {
+        header.addEventListener('click', () => {
+            const targetId = header.dataset.toggle;
+            const body = document.getElementById(targetId);
+            const icon = header.querySelector('.toggle-icon');
+
+            body.classList.toggle('collapsed');
+            icon.textContent = body.classList.contains('collapsed') ? '+' : '-';
+        });
+    });
+
+    // Query console
+    document.getElementById('run-query').addEventListener('click', () => {
+        const sql = document.getElementById('sql-input').value;
+        if (sql.trim()) {
+            runQuery(sql);
+        }
+    });
+
+    document.getElementById('clear-query').addEventListener('click', () => {
+        document.getElementById('sql-input').value = '';
+        document.getElementById('query-results').innerHTML = '';
+    });
+
+    // Example queries in SQL input placeholder
+    document.getElementById('sql-input').value =
+        "SELECT entity_type, COUNT(*) as count\nFROM entities\nGROUP BY entity_type\nORDER BY count DESC\nLIMIT 10";
+}
+
+// Initialize on load
+init();

--- a/netex_explorer/index.html
+++ b/netex_explorer/index.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>NeTEx Map Explorer</title>
+
+    <!-- Leaflet CSS -->
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+    <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.css" />
+    <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.Default.css" />
+
+    <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+    <!-- Loading Overlay -->
+    <div id="loading-overlay" class="loading-overlay">
+        <div class="loading-content">
+            <div class="spinner"></div>
+            <h2>Loading NeTEx Explorer</h2>
+            <p id="loading-status">Initializing DuckDB...</p>
+            <div class="progress-bar">
+                <div id="progress-fill" class="progress-fill"></div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Main Container -->
+    <div class="container">
+        <!-- Sidebar -->
+        <aside id="sidebar" class="sidebar">
+            <div class="sidebar-header">
+                <h1>NeTEx Explorer</h1>
+                <button id="mobile-close" class="mobile-close" aria-label="Close menu">&times;</button>
+            </div>
+
+            <div class="sidebar-content">
+                <!-- Data Source Info -->
+                <section class="panel">
+                    <h3>Data Source</h3>
+                    <div id="data-info" class="data-info">
+                        <p><strong>Import:</strong> <span id="import-date">Loading...</span></p>
+                        <p><strong>Entities:</strong> <span id="entity-count">-</span></p>
+                    </div>
+                </section>
+
+                <!-- Layer Controls -->
+                <section class="panel">
+                    <h3>Map Layers</h3>
+                    <div class="layer-controls">
+                        <label class="checkbox-label">
+                            <input type="checkbox" id="layer-stops" checked />
+                            <span class="checkbox-custom"></span>
+                            <span>Stop Places</span>
+                            <span id="stops-count" class="count-badge">-</span>
+                        </label>
+                        <label class="checkbox-label">
+                            <input type="checkbox" id="layer-quays" />
+                            <span class="checkbox-custom"></span>
+                            <span>Quays</span>
+                            <span id="quays-count" class="count-badge">-</span>
+                        </label>
+                        <label class="checkbox-label">
+                            <input type="checkbox" id="layer-lines" />
+                            <span class="checkbox-custom"></span>
+                            <span>Lines</span>
+                            <span id="lines-count" class="count-badge">-</span>
+                        </label>
+                    </div>
+                </section>
+
+                <!-- Search -->
+                <section class="panel">
+                    <h3>Search</h3>
+                    <div class="search-container">
+                        <input type="text" id="search-input" placeholder="Search stop places..." />
+                        <button id="search-btn" class="btn btn-primary">Search</button>
+                    </div>
+                    <div id="search-results" class="search-results"></div>
+                </section>
+
+                <!-- Entity Types Filter -->
+                <section class="panel">
+                    <h3>Entity Types</h3>
+                    <div id="entity-types" class="entity-types">
+                        <p class="loading-text">Loading types...</p>
+                    </div>
+                </section>
+
+                <!-- Selected Entity Details -->
+                <section class="panel" id="details-panel" style="display: none;">
+                    <h3>Selected Entity</h3>
+                    <div id="entity-details" class="entity-details"></div>
+                </section>
+
+                <!-- Query Console -->
+                <section class="panel collapsible">
+                    <h3 class="panel-header" data-toggle="query-console">
+                        SQL Query Console
+                        <span class="toggle-icon">+</span>
+                    </h3>
+                    <div id="query-console" class="panel-body collapsed">
+                        <textarea id="sql-input" placeholder="SELECT * FROM entities LIMIT 10"></textarea>
+                        <div class="query-actions">
+                            <button id="run-query" class="btn btn-primary">Run Query</button>
+                            <button id="clear-query" class="btn btn-secondary">Clear</button>
+                        </div>
+                        <div id="query-results" class="query-results"></div>
+                    </div>
+                </section>
+            </div>
+
+            <div class="sidebar-footer">
+                <a href="/" class="back-link">&larr; Back to Portfolio</a>
+            </div>
+        </aside>
+
+        <!-- Mobile Menu Button -->
+        <button id="mobile-menu-btn" class="mobile-menu-btn" aria-label="Open menu">
+            <span></span>
+            <span></span>
+            <span></span>
+        </button>
+
+        <!-- Map Container -->
+        <main class="map-container">
+            <div id="map"></div>
+
+            <!-- Map Controls -->
+            <div class="map-controls">
+                <button id="zoom-to-norway" class="map-control-btn" title="Zoom to Norway">
+                    <svg viewBox="0 0 24 24" width="20" height="20">
+                        <path fill="currentColor" d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/>
+                    </svg>
+                </button>
+            </div>
+
+            <!-- Info Box -->
+            <div id="hover-info" class="hover-info" style="display: none;"></div>
+        </main>
+    </div>
+
+    <!-- Scripts -->
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script src="https://unpkg.com/leaflet.markercluster@1.4.1/dist/leaflet.markercluster.js"></script>
+    <script type="module" src="app.js"></script>
+</body>
+</html>

--- a/netex_explorer/styles.css
+++ b/netex_explorer/styles.css
@@ -1,0 +1,713 @@
+/* CSS Variables */
+:root {
+    --color-primary: #2563eb;
+    --color-primary-dark: #1d4ed8;
+    --color-secondary: #10b981;
+    --color-accent: #f59e0b;
+    --color-danger: #ef4444;
+    --color-background: #f1f5f9;
+    --color-surface: #ffffff;
+    --color-text: #1e293b;
+    --color-text-muted: #64748b;
+    --color-border: #e2e8f0;
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
+    --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+    --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+    --radius-sm: 4px;
+    --radius-md: 8px;
+    --radius-lg: 12px;
+    --sidebar-width: 340px;
+    --transition: 0.2s ease;
+}
+
+/* Reset */
+*, *::before, *::after {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: var(--color-background);
+    color: var(--color-text);
+    line-height: 1.5;
+    overflow: hidden;
+}
+
+/* Loading Overlay */
+.loading-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.95);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 10000;
+    transition: opacity 0.5s ease;
+}
+
+.loading-overlay.hidden {
+    opacity: 0;
+    pointer-events: none;
+}
+
+.loading-content {
+    text-align: center;
+    color: white;
+    max-width: 400px;
+    padding: 2rem;
+}
+
+.loading-content h2 {
+    margin: 1rem 0 0.5rem;
+    font-size: 1.5rem;
+}
+
+.loading-content p {
+    color: #94a3b8;
+    font-size: 0.9rem;
+}
+
+.spinner {
+    width: 60px;
+    height: 60px;
+    border: 4px solid rgba(255, 255, 255, 0.2);
+    border-top-color: var(--color-primary);
+    border-radius: 50%;
+    margin: 0 auto;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}
+
+.progress-bar {
+    width: 100%;
+    height: 6px;
+    background: rgba(255, 255, 255, 0.2);
+    border-radius: 3px;
+    margin-top: 1.5rem;
+    overflow: hidden;
+}
+
+.progress-fill {
+    height: 100%;
+    background: var(--color-primary);
+    width: 0%;
+    transition: width 0.3s ease;
+}
+
+/* Container */
+.container {
+    display: flex;
+    height: 100vh;
+    width: 100vw;
+}
+
+/* Sidebar */
+.sidebar {
+    width: var(--sidebar-width);
+    background: var(--color-surface);
+    border-right: 1px solid var(--color-border);
+    display: flex;
+    flex-direction: column;
+    z-index: 100;
+    box-shadow: var(--shadow-md);
+}
+
+.sidebar-header {
+    padding: 1.25rem 1.5rem;
+    border-bottom: 1px solid var(--color-border);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background: linear-gradient(135deg, var(--color-primary), var(--color-primary-dark));
+    color: white;
+}
+
+.sidebar-header h1 {
+    font-size: 1.25rem;
+    font-weight: 600;
+}
+
+.mobile-close {
+    display: none;
+    background: none;
+    border: none;
+    color: white;
+    font-size: 1.75rem;
+    cursor: pointer;
+    line-height: 1;
+}
+
+.sidebar-content {
+    flex: 1;
+    overflow-y: auto;
+    padding: 1rem;
+}
+
+.sidebar-footer {
+    padding: 1rem 1.5rem;
+    border-top: 1px solid var(--color-border);
+    background: var(--color-background);
+}
+
+.back-link {
+    color: var(--color-text-muted);
+    text-decoration: none;
+    font-size: 0.875rem;
+    transition: color var(--transition);
+}
+
+.back-link:hover {
+    color: var(--color-primary);
+}
+
+/* Panels */
+.panel {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    padding: 1rem;
+    margin-bottom: 1rem;
+}
+
+.panel h3 {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--color-text);
+    margin-bottom: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.panel.collapsible .panel-header {
+    cursor: pointer;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0;
+}
+
+.panel.collapsible .panel-body {
+    overflow: hidden;
+    transition: max-height 0.3s ease;
+}
+
+.panel.collapsible .panel-body.collapsed {
+    max-height: 0;
+    padding: 0;
+    margin-top: 0;
+}
+
+.panel.collapsible .panel-body:not(.collapsed) {
+    max-height: 500px;
+    margin-top: 0.75rem;
+}
+
+.toggle-icon {
+    font-weight: bold;
+    color: var(--color-text-muted);
+}
+
+/* Data Info */
+.data-info p {
+    font-size: 0.875rem;
+    margin-bottom: 0.25rem;
+}
+
+.data-info span {
+    color: var(--color-text-muted);
+}
+
+/* Layer Controls */
+.layer-controls {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.checkbox-label {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    cursor: pointer;
+    padding: 0.5rem;
+    border-radius: var(--radius-sm);
+    transition: background var(--transition);
+}
+
+.checkbox-label:hover {
+    background: var(--color-background);
+}
+
+.checkbox-label input {
+    display: none;
+}
+
+.checkbox-custom {
+    width: 18px;
+    height: 18px;
+    border: 2px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all var(--transition);
+}
+
+.checkbox-label input:checked + .checkbox-custom {
+    background: var(--color-primary);
+    border-color: var(--color-primary);
+}
+
+.checkbox-label input:checked + .checkbox-custom::after {
+    content: '✓';
+    color: white;
+    font-size: 12px;
+    font-weight: bold;
+}
+
+.count-badge {
+    margin-left: auto;
+    background: var(--color-background);
+    color: var(--color-text-muted);
+    padding: 0.125rem 0.5rem;
+    border-radius: 999px;
+    font-size: 0.75rem;
+}
+
+/* Search */
+.search-container {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.search-container input {
+    flex: 1;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    font-size: 0.875rem;
+    outline: none;
+    transition: border-color var(--transition);
+}
+
+.search-container input:focus {
+    border-color: var(--color-primary);
+}
+
+.search-results {
+    margin-top: 0.75rem;
+    max-height: 200px;
+    overflow-y: auto;
+}
+
+.search-result-item {
+    padding: 0.5rem;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    font-size: 0.875rem;
+    border-bottom: 1px solid var(--color-border);
+    transition: background var(--transition);
+}
+
+.search-result-item:hover {
+    background: var(--color-background);
+}
+
+.search-result-item:last-child {
+    border-bottom: none;
+}
+
+.search-result-name {
+    font-weight: 500;
+}
+
+.search-result-type {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+}
+
+/* Entity Types */
+.entity-types {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.entity-type-tag {
+    padding: 0.25rem 0.75rem;
+    background: var(--color-background);
+    border: 1px solid var(--color-border);
+    border-radius: 999px;
+    font-size: 0.75rem;
+    cursor: pointer;
+    transition: all var(--transition);
+}
+
+.entity-type-tag:hover {
+    border-color: var(--color-primary);
+}
+
+.entity-type-tag.active {
+    background: var(--color-primary);
+    color: white;
+    border-color: var(--color-primary);
+}
+
+.loading-text {
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+}
+
+/* Entity Details */
+.entity-details {
+    font-size: 0.875rem;
+}
+
+.entity-details h4 {
+    font-size: 1rem;
+    margin-bottom: 0.5rem;
+}
+
+.entity-details .detail-row {
+    display: flex;
+    justify-content: space-between;
+    padding: 0.25rem 0;
+    border-bottom: 1px solid var(--color-border);
+}
+
+.entity-details .detail-row:last-child {
+    border-bottom: none;
+}
+
+.entity-details .detail-label {
+    color: var(--color-text-muted);
+}
+
+.entity-details .detail-value {
+    font-weight: 500;
+    text-align: right;
+    max-width: 60%;
+    word-break: break-word;
+}
+
+/* Query Console */
+#sql-input {
+    width: 100%;
+    min-height: 80px;
+    padding: 0.75rem;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    font-family: 'Monaco', 'Menlo', monospace;
+    font-size: 0.8rem;
+    resize: vertical;
+    outline: none;
+}
+
+#sql-input:focus {
+    border-color: var(--color-primary);
+}
+
+.query-actions {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+}
+
+.query-results {
+    margin-top: 0.75rem;
+    max-height: 200px;
+    overflow: auto;
+    font-size: 0.75rem;
+}
+
+.query-results table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.query-results th,
+.query-results td {
+    padding: 0.25rem 0.5rem;
+    border: 1px solid var(--color-border);
+    text-align: left;
+}
+
+.query-results th {
+    background: var(--color-background);
+    font-weight: 600;
+}
+
+/* Buttons */
+.btn {
+    padding: 0.5rem 1rem;
+    border: none;
+    border-radius: var(--radius-sm);
+    font-size: 0.875rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all var(--transition);
+}
+
+.btn-primary {
+    background: var(--color-primary);
+    color: white;
+}
+
+.btn-primary:hover {
+    background: var(--color-primary-dark);
+}
+
+.btn-secondary {
+    background: var(--color-background);
+    color: var(--color-text);
+    border: 1px solid var(--color-border);
+}
+
+.btn-secondary:hover {
+    background: var(--color-border);
+}
+
+/* Map Container */
+.map-container {
+    flex: 1;
+    position: relative;
+}
+
+#map {
+    width: 100%;
+    height: 100%;
+}
+
+/* Map Controls */
+.map-controls {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    z-index: 1000;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.map-control-btn {
+    width: 40px;
+    height: 40px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: var(--shadow-md);
+    transition: all var(--transition);
+}
+
+.map-control-btn:hover {
+    background: var(--color-background);
+}
+
+/* Hover Info */
+.hover-info {
+    position: absolute;
+    bottom: 1rem;
+    left: 50%;
+    transform: translateX(-50%);
+    background: var(--color-surface);
+    padding: 0.75rem 1rem;
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-lg);
+    z-index: 1000;
+    max-width: 400px;
+    font-size: 0.875rem;
+}
+
+/* Mobile Menu Button */
+.mobile-menu-btn {
+    display: none;
+    position: fixed;
+    top: 1rem;
+    left: 1rem;
+    z-index: 1001;
+    width: 44px;
+    height: 44px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 5px;
+    box-shadow: var(--shadow-md);
+}
+
+.mobile-menu-btn span {
+    display: block;
+    width: 20px;
+    height: 2px;
+    background: var(--color-text);
+    transition: all var(--transition);
+}
+
+/* Leaflet Custom Styles */
+.leaflet-popup-content-wrapper {
+    border-radius: var(--radius-md);
+}
+
+.leaflet-popup-content {
+    margin: 0.75rem 1rem;
+    font-size: 0.875rem;
+}
+
+.leaflet-popup-content h4 {
+    margin: 0 0 0.5rem;
+    font-size: 1rem;
+}
+
+.leaflet-popup-content p {
+    margin: 0.25rem 0;
+    color: var(--color-text-muted);
+}
+
+/* Cluster Markers */
+.marker-cluster-small {
+    background-color: rgba(37, 99, 235, 0.6);
+}
+
+.marker-cluster-small div {
+    background-color: rgba(37, 99, 235, 0.8);
+}
+
+.marker-cluster-medium {
+    background-color: rgba(16, 185, 129, 0.6);
+}
+
+.marker-cluster-medium div {
+    background-color: rgba(16, 185, 129, 0.8);
+}
+
+.marker-cluster-large {
+    background-color: rgba(245, 158, 11, 0.6);
+}
+
+.marker-cluster-large div {
+    background-color: rgba(245, 158, 11, 0.8);
+}
+
+.marker-cluster {
+    background-clip: padding-box;
+    border-radius: 50%;
+}
+
+.marker-cluster div {
+    width: 30px;
+    height: 30px;
+    margin-left: 5px;
+    margin-top: 5px;
+    text-align: center;
+    border-radius: 50%;
+    font: 12px system-ui, sans-serif;
+    color: white;
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+/* Stop marker styles */
+.stop-marker {
+    background: var(--color-primary);
+    border: 2px solid white;
+    border-radius: 50%;
+    width: 12px;
+    height: 12px;
+    box-shadow: var(--shadow-sm);
+}
+
+.quay-marker {
+    background: var(--color-secondary);
+    border: 2px solid white;
+    border-radius: 50%;
+    width: 8px;
+    height: 8px;
+    box-shadow: var(--shadow-sm);
+}
+
+/* Error States */
+.error-message {
+    background: #fef2f2;
+    color: var(--color-danger);
+    padding: 0.75rem;
+    border-radius: var(--radius-sm);
+    border: 1px solid #fecaca;
+    font-size: 0.875rem;
+}
+
+/* Mobile Responsive */
+@media (max-width: 768px) {
+    .sidebar {
+        position: fixed;
+        left: 0;
+        top: 0;
+        bottom: 0;
+        transform: translateX(-100%);
+        transition: transform 0.3s ease;
+        width: 100%;
+        max-width: var(--sidebar-width);
+    }
+
+    .sidebar.open {
+        transform: translateX(0);
+    }
+
+    .mobile-menu-btn {
+        display: flex;
+    }
+
+    .mobile-close {
+        display: block;
+    }
+
+    .map-controls {
+        top: 4.5rem;
+    }
+
+    .hover-info {
+        left: 1rem;
+        right: 1rem;
+        transform: none;
+        max-width: none;
+    }
+}
+
+/* Scrollbar Styling */
+.sidebar-content::-webkit-scrollbar,
+.search-results::-webkit-scrollbar,
+.query-results::-webkit-scrollbar {
+    width: 6px;
+}
+
+.sidebar-content::-webkit-scrollbar-track,
+.search-results::-webkit-scrollbar-track,
+.query-results::-webkit-scrollbar-track {
+    background: var(--color-background);
+}
+
+.sidebar-content::-webkit-scrollbar-thumb,
+.search-results::-webkit-scrollbar-thumb,
+.query-results::-webkit-scrollbar-thumb {
+    background: var(--color-border);
+    border-radius: 3px;
+}
+
+.sidebar-content::-webkit-scrollbar-thumb:hover,
+.search-results::-webkit-scrollbar-thumb:hover,
+.query-results::-webkit-scrollbar-thumb:hover {
+    background: var(--color-text-muted);
+}


### PR DESCRIPTION
New interactive map-based explorer for Norwegian public transit data:
- DuckDB WASM integration for querying parquet files directly in browser
- Leaflet map with marker clustering for performance
- Displays stop places and quays from NeTEx data
- Search functionality for finding stops by name
- SQL query console for custom data exploration
- Responsive sidebar with layer controls and entity details
- Loading states with progress indication

Data source: netex-parquet-dev GCS bucket aggregated dataset

https://claude.ai/code/session_01GVw7ghqXDY17MTMmEbuEPX